### PR TITLE
Do not pad secret if its length is a multiple of 8

### DIFF
--- a/util/totp.py
+++ b/util/totp.py
@@ -68,11 +68,12 @@ def _pre_process_key(key):
         bytes: byte array representation of the key"""
     key_len = len(key)
 
-    # pad the key
-    padding = key_len + (8 - (key_len % 8))
+    if key_len % 8 != 0:
+        # pad the key
+        padding = key_len + (8 - (key_len % 8))
 
-    # make the key of appropriate size with the base32 padding char
-    key = key.ljust(padding, b'=')
+        # make the key of appropriate size with the base32 padding char
+        key = key.ljust(padding, b'=')
 
     return base64.b32decode(key)
 


### PR DESCRIPTION
Test case that reproduces the issue:

    python3 totp.py JBSWY3DPEHPK3PXP

The above command results in this error:

    binascii.Error: Incorrect padding

The error occurs due to the fact that when the length of the secret is
already a multiple of 8, the padding code still adds another 8 equals
signs as padding. This fix ensures that no padding is added in this
case.